### PR TITLE
[Feature Request] Export results to SARIF for GitHub Security Dashboards

### DIFF
--- a/__tests__/configManager.test.js
+++ b/__tests__/configManager.test.js
@@ -1,0 +1,113 @@
+import { configManager } from '../src/config/configManager.js';
+
+describe('ConfigManager', () => {
+  beforeEach(() => {
+    configManager.config = null;
+    configManager.configPath = null;
+  });
+
+  describe('getConfigPaths', () => {
+    it('should return 3 config paths', () => {
+      const paths = configManager.getConfigPaths();
+      expect(paths).toHaveLength(3);
+      paths.forEach(p => expect(p).toContain('.sentinel.json'));
+    });
+  });
+
+  describe('get and set', () => {
+    beforeEach(() => {
+      configManager.config = JSON.parse(JSON.stringify(configManager.defaultConfig));
+    });
+
+    it('should return null for missing key', () => {
+      expect(configManager.get('nonexistent.key')).toBeNull();
+    });
+
+    it('should return value for existing key', () => {
+      expect(configManager.get('debug')).toBe(false);
+      expect(configManager.get('agents.coder.model')).toBe('gpt-4o-mini');
+    });
+
+    it('should set values via dot-notation', () => {
+      configManager.set('debug', true);
+      expect(configManager.get('debug')).toBe(true);
+    });
+
+    it('should create nested objects on set', () => {
+      configManager.set('custom.nested.key', 'val');
+      expect(configManager.get('custom.nested.key')).toBe('val');
+    });
+  });
+
+  describe('isProviderEnabled', () => {
+    beforeEach(() => {
+      configManager.config = JSON.parse(JSON.stringify(configManager.defaultConfig));
+    });
+
+    it('should return false for missing provider', () => {
+      expect(configManager.isProviderEnabled('nonexistent')).toBe(false);
+    });
+
+    it('should return false for disabled provider with no key', () => {
+      expect(configManager.isProviderEnabled('openai')).toBe(false);
+    });
+
+    it('should return true for enabled provider with key', () => {
+      configManager.config.providers.openai.apiKey = 'sk-test';
+      expect(configManager.isProviderEnabled('openai')).toBe(true);
+    });
+  });
+
+  describe('getConfiguredProviders', () => {
+    beforeEach(() => {
+      configManager.config = JSON.parse(JSON.stringify(configManager.defaultConfig));
+    });
+
+    it('should return empty array when no providers configured', () => {
+      expect(configManager.getConfiguredProviders()).toEqual([]);
+    });
+
+    it('should return providers with apiKey and not disabled', () => {
+      configManager.config.providers.openai.apiKey = 'sk-test';
+      configManager.config.providers.anthropic.apiKey = 'sk-ant';
+      expect(configManager.getConfiguredProviders()).toEqual(['openai', 'anthropic']);
+    });
+  });
+
+  describe('getMaskedConfig', () => {
+    beforeEach(() => {
+      configManager.config = JSON.parse(JSON.stringify(configManager.defaultConfig));
+    });
+
+    it('should mask API keys', () => {
+      configManager.config.providers.openai.apiKey = 'sk-abcdefghijklmnop';
+      const masked = configManager.getMaskedConfig();
+      expect(masked.providers.openai.apiKey).toBe('sk-a***********mnop');
+    });
+
+    it('should mask short API keys fully', () => {
+      configManager.config.providers.openai.apiKey = 'short';
+      const masked = configManager.getMaskedConfig();
+      expect(masked.providers.openai.apiKey).toBe('********');
+    });
+  });
+
+  describe('mergeDeep', () => {
+    it('should merge objects deeply', () => {
+      const target = { a: 1, b: { c: 2 } };
+      const source = { b: { d: 3 }, e: 4 };
+      const result = configManager.mergeDeep(target, source);
+      expect(result).toEqual({ a: 1, b: { c: 2, d: 3 }, e: 4 });
+    });
+
+    it('should override scalar values', () => {
+      const result = configManager.mergeDeep({ a: 1 }, { a: 2 });
+      expect(result.a).toBe(2);
+    });
+
+    it('should return source if target is not object', () => {
+      const result = configManager.mergeDeep(null, { a: 1 });
+      expect(result).toEqual({ a: 1 });
+    });
+  });
+});

--- a/__tests__/logger.test.js
+++ b/__tests__/logger.test.js
@@ -1,0 +1,79 @@
+import { jest } from '@jest/globals';
+import { Logger } from '../src/utils/logger.js';
+
+describe('Logger', () => {
+  let logger;
+  let consoleOutput;
+
+  beforeEach(() => {
+    consoleOutput = [];
+    jest.spyOn(console, 'debug').mockImplementation((...args) => { consoleOutput.push(['debug', ...args]); });
+    jest.spyOn(console, 'info').mockImplementation((...args) => { consoleOutput.push(['info', ...args]); });
+    jest.spyOn(console, 'warn').mockImplementation((...args) => { consoleOutput.push(['warn', ...args]); });
+    jest.spyOn(console, 'error').mockImplementation((...args) => { consoleOutput.push(['error', ...args]); });
+    logger = new Logger('info');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should default to info level', () => {
+    expect(logger.level).toBe('info');
+  });
+
+  it('should respect custom level', () => {
+    const l = new Logger('debug');
+    expect(l.level).toBe('debug');
+  });
+
+  it('should set level', () => {
+    logger.setLevel('debug');
+    expect(logger.level).toBe('debug');
+  });
+
+  it('should log info at info level', () => {
+    logger.info('test message');
+    expect(consoleOutput).toHaveLength(1);
+    expect(consoleOutput[0][0]).toBe('info');
+    expect(consoleOutput[0][2]).toBe('test message');
+  });
+
+  it('should not log debug at info level', () => {
+    logger.debug('should not appear');
+    expect(consoleOutput).toHaveLength(0);
+  });
+
+  it('should log debug at debug level', () => {
+    logger.setLevel('debug');
+    logger.debug('debug message');
+    expect(consoleOutput).toHaveLength(1);
+    expect(consoleOutput[0][0]).toBe('debug');
+  });
+
+  it('should log error at any level', () => {
+    logger.setLevel('error');
+    logger.error('error message');
+    expect(consoleOutput).toHaveLength(1);
+    expect(consoleOutput[0][0]).toBe('error');
+  });
+
+  it('should not log info above level', () => {
+    logger.setLevel('error');
+    logger.info('should not appear');
+    expect(consoleOutput).toHaveLength(0);
+  });
+
+  it('should log warn at warn level', () => {
+    logger.setLevel('warn');
+    logger.warn('warning');
+    expect(consoleOutput).toHaveLength(1);
+    expect(consoleOutput[0][0]).toBe('warn');
+  });
+
+  it('should handle multiple arguments', () => {
+    logger.info('prefix', { key: 'value' });
+    expect(consoleOutput[0][2]).toBe('prefix');
+    expect(consoleOutput[0][3]).toEqual({ key: 'value' });
+  });
+});

--- a/__tests__/sarif.test.js
+++ b/__tests__/sarif.test.js
@@ -1,0 +1,138 @@
+import { SarifGenerator } from '../src/output/sarifGenerator.js';
+
+describe('SarifGenerator', () => {
+  const sampleIssues = [
+    {
+      file: 'src/app.js',
+      line: 10,
+      column: 5,
+      title: 'Hardcoded API key',
+      message: 'API key found in source code',
+      severity: 'critical',
+      type: 'security',
+      analyzer: 'security-analyzer',
+      suggestion: 'Use environment variables instead',
+      snippet: 'const key = "sk-12345"',
+    },
+    {
+      file: 'src/utils.js',
+      line: 25,
+      title: 'Unused variable',
+      message: 'Variable "temp" is declared but never used',
+      severity: 'medium',
+      type: 'quality',
+      analyzer: 'linter',
+    },
+  ];
+
+  let generator;
+
+  beforeEach(() => {
+    generator = new SarifGenerator();
+  });
+
+  it('generates valid SARIF 2.1.0 structure', () => {
+    const sarif = generator.generate(sampleIssues);
+
+    expect(sarif.$schema).toContain('sarif-schema-2.1.0.json');
+    expect(sarif.version).toBe('2.1.0');
+    expect(sarif.runs).toHaveLength(1);
+  });
+
+  it('includes tool driver metadata', () => {
+    const sarif = generator.generate(sampleIssues);
+    const driver = sarif.runs[0].tool.driver;
+
+    expect(driver.name).toBe('Sentinel CLI');
+    expect(driver.informationUri).toContain('github.com');
+  });
+
+  it('maps critical severity to error level', () => {
+    const sarif = generator.generate(sampleIssues);
+    const criticalResult = sarif.runs[0].results.find(r => r.ruleId.includes('hardcoded-api-key'));
+
+    expect(criticalResult).toBeDefined();
+    expect(criticalResult.level).toBe('error');
+  });
+
+  it('maps medium severity to warning level', () => {
+    const sarif = generator.generate(sampleIssues);
+    const mediumResult = sarif.runs[0].results.find(r => r.ruleId.includes('unused-variable'));
+
+    expect(mediumResult).toBeDefined();
+    expect(mediumResult.level).toBe('warning');
+  });
+
+  it('includes location information for each result', () => {
+    const sarif = generator.generate(sampleIssues);
+    const result = sarif.runs[0].results[0];
+
+    expect(result.locations).toHaveLength(1);
+    expect(result.locations[0].physicalLocation.artifactLocation.uri).toBe('src/app.js');
+    expect(result.locations[0].physicalLocation.region.startLine).toBe(10);
+    expect(result.locations[0].physicalLocation.region.startColumn).toBe(5);
+  });
+
+  it('includes code snippet when available', () => {
+    const sarif = generator.generate(sampleIssues);
+    const result = sarif.runs[0].results.find(r => r.ruleId.includes('hardcoded-api-key'));
+
+    expect(result.locations[0].physicalLocation.region.snippet).toBeDefined();
+    expect(result.locations[0].physicalLocation.region.snippet.text).toBe('const key = "sk-12345"');
+  });
+
+  it('includes fix suggestions when available', () => {
+    const sarif = generator.generate(sampleIssues);
+    const result = sarif.runs[0].results.find(r => r.ruleId.includes('hardcoded-api-key'));
+
+    expect(result.fixes).toHaveLength(1);
+    expect(result.fixes[0].description.text).toBe('Use environment variables instead');
+  });
+
+  it('defines unique rules from issues', () => {
+    const sarif = generator.generate(sampleIssues);
+    const rules = sarif.runs[0].tool.driver.rules;
+
+    expect(rules).toHaveLength(2);
+    expect(rules[0].id).toContain('sentinel');
+    expect(rules[0].shortDescription).toBeDefined();
+    expect(rules[0].fullDescription).toBeDefined();
+  });
+
+  it('handles empty issues array', () => {
+    const sarif = generator.generate([]);
+
+    expect(sarif.runs[0].results).toHaveLength(0);
+    expect(sarif.runs[0].tool.driver.rules).toHaveLength(0);
+  });
+
+  it('includes invocation metadata', () => {
+    const sarif = generator.generate(sampleIssues);
+    const invocation = sarif.runs[0].invocations[0];
+
+    expect(invocation.executionSuccessful).toBe(true);
+    expect(invocation.endTimeUtc).toBeDefined();
+  });
+
+  it('saves SARIF to file', async () => {
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const tmpDir = process.env.TEMP || '/tmp';
+    const outputPath = path.join(tmpDir, 'test-sarif-output.sarif');
+
+    const resultPath = await generator.saveToFile(sampleIssues, outputPath);
+    expect(resultPath).toBe(outputPath);
+
+    const content = await fs.readFile(outputPath, 'utf8');
+    const parsed = JSON.parse(content);
+    expect(parsed.version).toBe('2.1.0');
+
+    await fs.unlink(outputPath);
+  });
+
+  it('rejects path traversal in output path', async () => {
+    await expect(
+      generator.saveToFile(sampleIssues, '../malicious.sarif')
+    ).rejects.toThrow('Path traversal');
+  });
+});

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1804,27 +1804,15 @@ program
 
 // NEW: SARIF output for GitHub Security
 program
-  .command('sarif')
-  .description('Generate SARIF report for GitHub Security tab')
-  .option('-o, --output <file>', 'Output file path', 'sentinel-results.sarif')
-  .action(async options => {
+  .command('sarif [input-file]')
+  .description('Export analysis results to SARIF 2.1.0 format')
+  .option('-o, --output <file>', 'Output file (defaults to stdout)')
+  .action(async (inputFile, options) => {
     try {
-      const { SarifGenerator } = await import('./output/sarifGenerator.js');
-      const bot = new CodeReviewBot();
-      await bot.initialize();
-
-      console.log(chalk.cyan('🔍 Running analysis...'));
-      const { issues } = await bot.runAnalysis({ format: 'json', silent: true });
-
-      const sarif = new SarifGenerator();
-      await sarif.saveToFile(issues, options.output);
-
-      console.log(chalk.green('✓') + ` SARIF report saved to ${options.output}`);
-      console.log(
-        chalk.gray('  Upload to GitHub: gh code-scanning upload-sarif --sarif ' + options.output)
-      );
-    } catch (error) {
-      console.error(chalk.red('SARIF generation failed:'), error.message);
+      const { default: runSarif } = await import('./cli/commands/sarif.js');
+      await runSarif(inputFile, options);
+    } catch (err) {
+      console.error(chalk.red('SARIF export failed:'), err.message);
       process.exit(1);
     }
   });

--- a/dist/cli/commands/sarif.js
+++ b/dist/cli/commands/sarif.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import { promises as fs } from 'fs';
+
+export async function runSarif(inputFile, options = {}) {
+  const { SarifGenerator } = await import('../../output/sarifGenerator.js');
+  const generator = new SarifGenerator();
+
+  let issues;
+
+  if (inputFile) {
+    const content = await fs.readFile(inputFile, 'utf8');
+    const parsed = JSON.parse(content);
+    issues = parsed.issues || parsed;
+  } else {
+    const stdin = await readStdin();
+    if (stdin) {
+      const parsed = JSON.parse(stdin);
+      issues = parsed.issues || parsed;
+    } else {
+      issues = [];
+    }
+  }
+
+  if (!Array.isArray(issues)) {
+    throw new Error('Input must contain an "issues" array or be an array itself');
+  }
+
+  const sarif = generator.generate(issues);
+
+  if (options.output) {
+    await fs.writeFile(options.output, JSON.stringify(sarif, null, 2), 'utf8');
+    console.log(`SARIF report saved to ${options.output}`);
+  } else {
+    console.log(JSON.stringify(sarif, null, 2));
+  }
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    if (process.stdin.isTTY) return resolve('');
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+const isDirectRun =
+  typeof process.argv[1] === 'string' &&
+  process.argv[1] === new URL(import.meta.url).pathname;
+
+if (isDirectRun) {
+  const inputFile = process.argv[2];
+  const outputIndex = process.argv.indexOf('-o');
+  const output = outputIndex !== -1 ? process.argv[outputIndex + 1] : undefined;
+  await runSarif(inputFile, { output });
+}
+
+export default runSarif;

--- a/dist/output/sarifGenerator.js
+++ b/dist/output/sarifGenerator.js
@@ -7,7 +7,7 @@ import { promises as fs } from 'fs';
 export class SarifGenerator {
     constructor(options = {}) {
         this.toolName = options.toolName || 'Sentinel CLI';
-        this.toolVersion = options.toolVersion || '1.2.2';
+        this.toolVersion = options.toolVersion || '2.0.2';
         this.toolUri = options.toolUri || 'https://github.com/KunjShah95/Sentinel-CLI';
     }
 

--- a/src/cli/commands/sarif.js
+++ b/src/cli/commands/sarif.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+import { promises as fs } from 'fs';
+
+export async function runSarif(inputFile, options = {}) {
+  const { SarifGenerator } = await import('../../output/sarifGenerator.js');
+  const generator = new SarifGenerator();
+
+  let issues;
+
+  if (inputFile) {
+    const content = await fs.readFile(inputFile, 'utf8');
+    const parsed = JSON.parse(content);
+    issues = parsed.issues || parsed;
+  } else {
+    const stdin = await readStdin();
+    if (stdin) {
+      const parsed = JSON.parse(stdin);
+      issues = parsed.issues || parsed;
+    } else {
+      issues = [];
+    }
+  }
+
+  if (!Array.isArray(issues)) {
+    throw new Error('Input must contain an "issues" array or be an array itself');
+  }
+
+  const sarif = generator.generate(issues);
+
+  if (options.output) {
+    await fs.writeFile(options.output, JSON.stringify(sarif, null, 2), 'utf8');
+    console.log(`SARIF report saved to ${options.output}`);
+  } else {
+    console.log(JSON.stringify(sarif, null, 2));
+  }
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    if (process.stdin.isTTY) return resolve('');
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+const isDirectRun =
+  typeof process.argv[1] === 'string' &&
+  process.argv[1] === new URL(import.meta.url).pathname;
+
+if (isDirectRun) {
+  const inputFile = process.argv[2];
+  const outputIndex = process.argv.indexOf('-o');
+  const output = outputIndex !== -1 ? process.argv[outputIndex + 1] : undefined;
+  await runSarif(inputFile, { output });
+}
+
+export default runSarif;

--- a/src/dist/cli.js
+++ b/src/dist/cli.js
@@ -1804,27 +1804,15 @@ program
 
 // NEW: SARIF output for GitHub Security
 program
-  .command('sarif')
-  .description('Generate SARIF report for GitHub Security tab')
-  .option('-o, --output <file>', 'Output file path', 'sentinel-results.sarif')
-  .action(async options => {
+  .command('sarif [input-file]')
+  .description('Export analysis results to SARIF 2.1.0 format')
+  .option('-o, --output <file>', 'Output file (defaults to stdout)')
+  .action(async (inputFile, options) => {
     try {
-      const { SarifGenerator } = await import('../output/sarifGenerator.js');
-      const bot = new CodeReviewBot();
-      await bot.initialize();
-
-      console.log(chalk.cyan('🔍 Running analysis...'));
-      const { issues } = await bot.runAnalysis({ format: 'json', silent: true });
-
-      const sarif = new SarifGenerator();
-      await sarif.saveToFile(issues, options.output);
-
-      console.log(chalk.green('✓') + ` SARIF report saved to ${options.output}`);
-      console.log(
-        chalk.gray('  Upload to GitHub: gh code-scanning upload-sarif --sarif ' + options.output)
-      );
-    } catch (error) {
-      console.error(chalk.red('SARIF generation failed:'), error.message);
+      const { default: runSarif } = await import('../cli/commands/sarif.js');
+      await runSarif(inputFile, options);
+    } catch (err) {
+      console.error(chalk.red('SARIF export failed:'), err.message);
       process.exit(1);
     }
   });

--- a/src/output/sarifGenerator.js
+++ b/src/output/sarifGenerator.js
@@ -7,7 +7,7 @@ import { promises as fs } from 'fs';
 export class SarifGenerator {
     constructor(options = {}) {
         this.toolName = options.toolName || 'Sentinel CLI';
-        this.toolVersion = options.toolVersion || '1.2.2';
+        this.toolVersion = options.toolVersion || '2.0.2';
         this.toolUri = options.toolUri || 'https://github.com/KunjShah95/Sentinel-CLI';
     }
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,13 @@
+export class Logger {
+  constructor(level = 'info') {
+    this.level = level;
+    this.levels = { debug: 0, info: 1, warn: 2, error: 3 };
+  }
+
+  setLevel(level) { this.level = level; }
+
+  debug(...args) { if (this.levels[this.level] <= 0) console.debug('[DEBUG]', ...args); }
+  info(...args) { if (this.levels[this.level] <= 1) console.info('[INFO]', ...args); }
+  warn(...args) { if (this.levels[this.level] <= 2) console.warn('[WARN]', ...args); }
+  error(...args) { if (this.levels[this.level] <= 3) console.error('[ERROR]', ...args); }
+}


### PR DESCRIPTION
Closes #3

Implements \sentinel sarif\ command that converts internal analysis results to standard SARIF 2.1.0 format for GitHub Security Dashboard integration.